### PR TITLE
Remove shop record on app/uninstalled webhook

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :test do
   gem 'selenium-webdriver'
   # Easy installation and use of web drivers to run system tests with browsers
   gem 'webdrivers'
+  gem 'mocha'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
+    mocha (1.12.0)
     msgpack (1.3.3)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -273,6 +274,7 @@ DEPENDENCIES
   graphql
   jbuilder (~> 2.7)
   listen (~> 3.2)
+  mocha
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)
   react-rails

--- a/app/jobs/app_uninstalled_job.rb
+++ b/app/jobs/app_uninstalled_job.rb
@@ -8,6 +8,6 @@ class AppUninstalledJob < ActiveJob::Base
   private
 
   def mark_shop_as_uninstalled(shop)
-    shop.destroy! if shop
+    shop.uninstall! if shop
   end
 end

--- a/app/jobs/app_uninstalled_job.rb
+++ b/app/jobs/app_uninstalled_job.rb
@@ -1,0 +1,13 @@
+class AppUninstalledJob < ActiveJob::Base
+  def perform(args)
+    shop = Shop.find_by(shopify_domain: args[:shop_domain])
+
+    mark_shop_as_uninstalled(shop)
+  end
+
+  private
+
+  def mark_shop_as_uninstalled(shop)
+    shop.destroy! if shop
+  end
+end

--- a/app/jobs/register_webhooks_for_active_shops.rb
+++ b/app/jobs/register_webhooks_for_active_shops.rb
@@ -1,0 +1,19 @@
+class RegisterWebhooksForActiveShops < ApplicationJob
+  queue_as :default
+
+  def perform
+    register_webhooks_for_active_shops
+  end
+
+  private
+
+  def register_webhooks_for_active_shops
+    Shop.find_each do |shop|
+      ShopifyApp::WebhooksManagerJob.perform_now(
+        shop_domain: shop.shopify_domain,
+        shop_token: shop.shopify_token,
+        webhooks: ShopifyApp.configuration.webhooks
+      )
+    end
+  end
+end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -2,6 +2,14 @@
 class Shop < ActiveRecord::Base
   include ShopifyApp::ShopSessionStorage
 
+  def uninstall
+    destroy
+  end
+
+  def uninstall!
+    destroy!
+  end
+
   def api_version
     ShopifyApp.configuration.api_version
   end

--- a/config/initializers/shopify_app.rb
+++ b/config/initializers/shopify_app.rb
@@ -10,6 +10,9 @@ ShopifyApp.configure do |config|
   config.api_version = "2020-07"
   config.shop_session_repository = 'Shop'
   config.allow_jwt_authentication = true
+  config.webhooks = [
+    {topic: 'app/uninstalled', address: "#{ENV['APP_URL']}/webhooks/app_uninstalled", format: 'json'},
+  ]
 end
 
 # ShopifyApp::Utils.fetch_known_api_versions                        # Uncomment to fetch known api versions from shopify servers on boot

--- a/test/fixtures/shops.yml
+++ b/test/fixtures/shops.yml
@@ -1,3 +1,7 @@
 regular_shop:
   shopify_domain: 'regular-shop.myshopify.com'
   shopify_token: 'token'
+
+second_shop:
+  shopify_domain: 'second-shop.myshopify.com'
+  shopify_token: 'token1'

--- a/test/helpers/shop_lifecycle_test_helper.rb
+++ b/test/helpers/shop_lifecycle_test_helper.rb
@@ -1,0 +1,17 @@
+module ShopLifecycleTestHelper
+  def assert_uninstalls(shopify_domain, &block)
+    assert_difference 'Shop.count', -1, "one shop should have been uninstalled", &block
+
+    assert_nil Shop.find_by(shopify_domain: shopify_domain), "shop #{shopify_domain} is still installed"
+  end
+
+  def assert_installed(shopify_domain)
+    assert_not_nil Shop.find_by(shopify_domain: shopify_domain)
+  end
+
+  def assert_no_installation_change
+    assert_difference 'Shop.count', 0 do
+      yield
+    end
+  end
+end

--- a/test/jobs/app_uninstalled_job_test.rb
+++ b/test/jobs/app_uninstalled_job_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AppUninstalledJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/jobs/app_uninstalled_job_test.rb
+++ b/test/jobs/app_uninstalled_job_test.rb
@@ -1,7 +1,27 @@
 require 'test_helper'
 
 class AppUninstalledJobTest < ActiveJob::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  def setup
+    @shop_1 = shops(:regular_shop)
+    @shop_2 = shops(:second_shop)
+  end
+
+  def job
+    @job ||= ::AppUninstalledJob.new
+  end
+
+  test "AppUninstalledJob marks the shop as uninstalled from the app" do
+    assert_difference 'Shop.count', -1 do
+      job.perform(shop_domain: @shop_1.shopify_domain)
+    end
+
+    assert_nil Shop.find_by(shopify_domain: @shop_1.shopify_domain)
+    assert_equal @shop_2, Shop.find_by(shopify_domain: @shop_2.shopify_domain)
+  end
+
+  test "AppUninstalledJob does nothing for non-existent shop" do
+    assert_difference 'Shop.count', 0 do
+      job.perform(shop_domain: 'example.myshopify.com')
+    end
+  end
 end

--- a/test/jobs/app_uninstalled_job_test.rb
+++ b/test/jobs/app_uninstalled_job_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
+require 'helpers/shop_lifecycle_test_helper'
 
 class AppUninstalledJobTest < ActiveJob::TestCase
+  include ShopLifecycleTestHelper
+
   def setup
     @shop_1 = shops(:regular_shop)
     @shop_2 = shops(:second_shop)
@@ -11,16 +14,15 @@ class AppUninstalledJobTest < ActiveJob::TestCase
   end
 
   test "AppUninstalledJob marks the shop as uninstalled from the app" do
-    assert_difference 'Shop.count', -1 do
+    assert_uninstalls @shop_1.shopify_domain do
       job.perform(shop_domain: @shop_1.shopify_domain)
     end
 
-    assert_nil Shop.find_by(shopify_domain: @shop_1.shopify_domain)
-    assert_equal @shop_2, Shop.find_by(shopify_domain: @shop_2.shopify_domain)
+    assert_installed @shop_2.shopify_domain
   end
 
   test "AppUninstalledJob does nothing for non-existent shop" do
-    assert_difference 'Shop.count', 0 do
+    assert_no_installation_change do
       job.perform(shop_domain: 'example.myshopify.com')
     end
   end

--- a/test/jobs/register_webhooks_for_active_shops_test.rb
+++ b/test/jobs/register_webhooks_for_active_shops_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class RegisterWebhooksForActiveShopsTest < ActiveJob::TestCase
+  def setup
+    @shop_1 = shops(:regular_shop)
+    @shop_2 = shops(:second_shop)
+  end
+
+  def job
+    @job ||= ::RegisterWebhooksForActiveShops.new
+  end
+
+
+  test "RegisterWebhooksForActiveShops registers webhooks for all existing shops" do
+    ShopifyApp::WebhooksManagerJob.expects(:perform_now).with(
+      shop_domain: @shop_1.shopify_domain,
+      shop_token: @shop_1.shopify_token,
+      webhooks: ShopifyApp.configuration.webhooks
+    ).once
+
+    ShopifyApp::WebhooksManagerJob.expects(:perform_now).with(
+      shop_domain: @shop_2.shopify_domain,
+      shop_token: @shop_2.shopify_token,
+      webhooks: ShopifyApp.configuration.webhooks
+    ).once
+
+    job.perform_now
+  end
+end

--- a/test/models/shop_test.rb
+++ b/test/models/shop_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+require 'helpers/shop_lifecycle_test_helper'
+
+class ShopTest < ActiveSupport::TestCase
+  include ShopLifecycleTestHelper
+
+  def setup
+    @shop_1 = shops(:regular_shop)
+    @shop_2 = shops(:second_shop)
+  end
+
+  test "#uninstall marks the shop as uninstalled" do
+    assert_uninstalls @shop_1.shopify_domain do
+      @shop_1.uninstall
+    end
+
+    assert_nil Shop.find_by(shopify_domain: @shop_1.shopify_domain)
+    assert_equal @shop_2, Shop.find_by(shopify_domain: @shop_2.shopify_domain)
+  end
+
+  test "#uninstall! marks the shop as uninstalled" do
+    @shop_1.uninstall!
+
+    assert_nil Shop.find_by(shopify_domain: @shop_1.shopify_domain)
+    assert_equal @shop_2, Shop.find_by(shopify_domain: @shop_2.shopify_domain)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,9 @@
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
+require "mocha/setup"
+require 'minitest'
+require 'minitest/autorun'
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers


### PR DESCRIPTION
This PR introduces the setup for the `app/uninstalled` webhook. The app will run the `AppUninstalledJob` when an `app/uninstalled` webhook arrives and mark the shop as uninstalled.

🎩 **For new shops**
1. Run the app on production shop (ensure to go through OAuth in order for the webhook to be registered)
2. Ensure shop record exists on the app
3. Uninstall app from shop
4. Notice `app/uninstalled` webhook to be picked up on app logs and the shop record deleted

🎩 **For existing shops**
1. Run `master` branch of the app and install it on the production shop, ensuring that the webhook was not registered
2. Open a Rails console and run `RegisterWebhooksForActiveShops.perform_now` to register webhooks for all shops in the database
3. Uninstall app from shop
4. Notice `app/uninstalled` webhook to be picked up on app logs and the shop record deleted