### PR TITLE
specify a version when you use the unpkg cdn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ vendor
 .generators
 .idea/
 .rakeTasks
+branch_structure.json
+temp_auto_push.bat
+temp_interactive_push.bat

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,19 +4,24 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
-#   # If you are using webpack-dev-server then specify webpack-dev-server host
-#   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+initial_frame_ancestors = [:https, "*.myshopify.com", "admin.shopify.com"]
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+def current_domain
+  @current_domain ||= (params[:shop] && ShopifyApp::Utils.sanitize_shop_domain(params[:shop])) ||
+    request.env["jwt.shopify_domain"] ||
+    session[:shopify_domain]
+end
+
+frame_ancestors = lambda { [ current_domain, "admin.shopify.com" ] || initial_frame_ancestors }
+
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src(:https, :self)
+  policy.style_src(:https, "cdn.shopifycloud.com")
+  policy.script_src(:https, "cdn.shopifycloud.com")
+  policy.img_src(:self, :https, :data, "cdn.shopifycloud.com")
+  policy.upgrade_insecure_requests(true)
+  policy.frame_ancestors(frame_ancestors)
+end
 
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }


### PR DESCRIPTION
Make sure that you specify a version when you use the unpkg cdn. If you do not your app could break when breaking changes are introduced to App Bridge.