### PR TITLE
Fix issue with CSP condition

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,7 +12,7 @@ def current_domain
     session[:shopify_domain]
 end
 
-frame_ancestors = lambda { [ current_domain, "admin.shopify.com" ] || initial_frame_ancestors }
+frame_ancestors = lambda { current_domain ? [ current_domain, "admin.shopify.com" ] : initial_frame_ancestors }
 
 Rails.application.config.content_security_policy do |policy|
   policy.default_src(:https, :self)


### PR DESCRIPTION
## What ?
The expectation is to set the CSP to `https *.myshopify.com admin.shopify.com` for unauthenticated app pages and `[shop].myshopify.com admin.shopify.com` for authenticated ones.
 
## Details
The previous condition assigning the CSP was causing and issue for pre-auth calls as it would set the CSP to `[nil, "admin.shopify.com"]` instead of defaulting to the `initial_frame_ancestors` variable value.